### PR TITLE
Update Munki Python path

### DIFF
--- a/list_munki_items.py
+++ b/list_munki_items.py
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 
 import argparse
 import csv


### PR DESCRIPTION
Munki no longer uses `/usr/local/munki/python`, so this PR updates for the new path.